### PR TITLE
Fix List responses

### DIFF
--- a/drf_kit/views/viewsets.py
+++ b/drf_kit/views/viewsets.py
@@ -186,3 +186,6 @@ class BulkMixin(MultiSerializerMixin):
                 'many': True
             }
         return {}
+
+    def update(self, request, *args, **kwargs):
+        raise MethodNotAllowed(method='patch')

--- a/test_app/tests/tests_views/test_bulk_views.py
+++ b/test_app/tests/tests_views/test_bulk_views.py
@@ -70,14 +70,7 @@ class TestBulkView(TestCRUDView):
             'points_boost': 3.14,
         }
         response = self.client.patch(url, data=data)
-        self.assertEqual(200, response.status_code)
-
-        expected_house = self.expected_houses[0]
-        expected_house['points_boost'] = "3.14"
-        self.assertEqual(expected_house, response.json())
-
-        houses = models.House.objects.all()
-        self.assertEqual(4, houses.count())
+        self.assertEqual(405, response.status_code)
 
     def test_put_endpoint(self):
         house = self.houses[0]

--- a/test_app/tests/tests_views/tests_nested_views.py
+++ b/test_app/tests/tests_views/tests_nested_views.py
@@ -26,11 +26,9 @@ class TestNestedView(HogwartsTestMixin, BaseApiTest):
         self.assertEqual(2, len(data['results']))
 
         expected_data = [
-            self.expected_detailed_wizards[1],
-            self.expected_detailed_wizards[0],
+            self.expected_wizards[1],
+            self.expected_wizards[0],
         ]
-        expected_data[1]['house'] = self.expected_houses[0]
-        expected_data[0]['house'] = self.expected_houses[0]
 
         self.assertEqual(expected_data, data['results'])
 

--- a/test_app/tests/tests_views/tests_very_custom_views.py
+++ b/test_app/tests/tests_views/tests_very_custom_views.py
@@ -20,7 +20,7 @@ class TestVeryCustomView(HogwartsTestMixin, BaseApiTest):
         data = response.json()
         self.assertEqual(4, len(data['results']))
 
-        expected = list(reversed(self.expected_detailed_wizards))
+        expected = list(reversed(self.expected_wizards))
         self.assertEqual(expected, data['results'])
 
     def test_detail_endpoint_out_of_queryset(self):


### PR DESCRIPTION
Refactor how input/output serializers and queryset are defined.
This add predictability to responses, assuring that responses when writing are consistent with responses when reading:
- list request [`GET /`]: list response
- detail request [`GET /<id>`]: detail response
- create request [`POST /`]: detail response (or list response, when bulk)
- update request [`PATCH /<id>`]: detail response(or list response, when bulk)